### PR TITLE
Fix issue with Linux builds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ artifact
 
 .vs
 .vscode
+.cache
 
 .gitbak
 out

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -221,7 +221,7 @@ target_link_libraries(firelight_lib PUBLIC
         patching
         rcheevos
         discord
-        discord_partner_sdk)
+        )
 
 # qt_import_plugins(firelight_lib
 #         INCLUDE QFFmpegMediaPlugin)


### PR DESCRIPTION
Fixes an issue with Linux builds failing to link. The linker was searching in two locations for the Discord SDK, and failing after being unable to find anything in one of the locations.

NOTE: This has not been tested on Windows