### PR TITLE
Define the application desktop file name

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -88,6 +88,7 @@ int main(int argc, char *argv[]) {
   }
 
   QGuiApplication::setOrganizationDomain("firelight-emulator.com");
+  QGuiApplication::setDesktopFileName("firelight-emu");
   QGuiApplication::setApplicationName("Firelight");
 
   QSettings::setDefaultFormat(QSettings::Format::IniFormat);


### PR DESCRIPTION
Sets the desktopFileName for the application. This is specific for Linux builds to ensure that the correct icon is shown when the application is running.