### PR TITLE
Fix build error with QtGuiPrivate

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -71,6 +71,11 @@ find_package(SDL2 REQUIRED)
 find_package(spdlog REQUIRED)
 # find_package(FFMPEG REQUIRED COMPONENTS AVCODEC AVFORMAT AVUTIL SWSCALE SWRESAMPLE)
 find_package(Qt6 6.8 REQUIRED COMPONENTS Quick Gui OpenGL QuickControls2 Quick3D Sql QuickTest Multimedia Network Widgets Svg REQUIRED)
+if (Qt6_VERSION VERSION_GREATER_EQUAL 6.10.0)
+    find_package(Qt6 OPTIONAL_COMPONENTS
+        GuiPrivate
+    )
+endif()
 find_package(cpr REQUIRED)
 find_package(GTest REQUIRED)
 find_package(nlohmann_json REQUIRED)


### PR DESCRIPTION
With the release of Qt 6.10, it seems that they restructured some files, leading to QtGuiPrivate not being located for linking. This commit modifies the CMake configuration to correct for that version and higher.